### PR TITLE
DBコンテナ起動エラーの修正

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,8 @@ services:
     image: mysql:8.0
     environment:
       MYSQL_DATABASE: paddle
-      MYSQL_USER: root
+      MYSQL_USER: apuser
+      MYSQL_PASSWORD: password
       MYSQL_ROOT_PASSWORD: password
       TZ: 'Asia/Tokyo'
     command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci

--- a/internal/infrastructure/database/db.go
+++ b/internal/infrastructure/database/db.go
@@ -12,6 +12,6 @@ var (
 // Init is a method to initialize the database connection
 func Init() {
 	// https://qiita.com/daiki-murakami/items/c8f9df8defc937e185ee#go%E3%81%A8mysql%E3%82%92%E6%8E%A5%E7%B6%9A%E3%81%99%E3%82%8B
-	db, _ := sql.Open("mysql", "root:password@tcp(db:3306)/paddle?charset=utf8&parseTime=true&loc=Asia%2FTokyo")
+	db, _ := sql.Open("mysql", "apuser:password@tcp(db:3306)/paddle?charset=utf8&parseTime=true&loc=Asia%2FTokyo")
 	DBCon = db
 }


### PR DESCRIPTION
#6

### 修正前
コード1で終了している
```
db_1   | 2021-04-17 04:17:12+09:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
db_1   | 2021-04-17 04:17:12+09:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.23-1debian10 started.
db_1   | 2021-04-17 04:17:13+09:00 [ERROR] [Entrypoint]: MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD are for configuring a regular user and cannot be used for the root user
db_1   |     Remove MYSQL_USER="root" and use one of the following to control the root user password:
db_1   |     - MYSQL_ROOT_PASSWORD
db_1   |     - MYSQL_ALLOW_EMPTY_PASSWORD
db_1   |     - MYSQL_RANDOM_ROOT_PASSWORD
paddle_db_1 exited with code 1
```

### 修正後
```
$ docker ps
CONTAINER ID   IMAGE        COMMAND                  CREATED          STATUS              PORTS                               NAMES
7033777daa03   paddle_go    "/bin/sh -c 'go get …"   14 minutes ago   Up About a minute   0.0.0.0:10330->10330/tcp            paddle_go_1
543f9e527da1   mysql:8.0    "docker-entrypoint.s…"   14 minutes ago   Up 2 minutes        33060/tcp, 0.0.0.0:8001->3306/tcp   paddle_db_1
e8311574e07e   paddle_web   "docker-entrypoint.s…"   41 hours ago     Up 2 minutes        0.0.0.0:13000->13000/tcp            paddle_web_1
```


```
db_1   | 2021-04-18 22:09:38+09:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.23-1debian10 started.
db_1   | 2021-04-18 22:09:38+09:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
db_1   | 2021-04-18 22:09:38+09:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.23-1debian10 started.
db_1   | 2021-04-18T13:09:39.689046Z 0 [System] [MY-010116] [Server] /usr/sbin/mysqld (mysqld 8.0.23) starting as process 1
db_1   | 2021-04-18T13:09:39.717933Z 1 [System] [MY-013576] [InnoDB] InnoDB initialization has started.
db_1   | 2021-04-18T13:09:40.333673Z 1 [System] [MY-013577] [InnoDB] InnoDB initialization has ended.
db_1   | 2021-04-18T13:09:40.753517Z 0 [System] [MY-011323] [Server] X Plugin ready for connections. Bind-address: '::' port: 33060, socket: /var/run/mysqld/mysqlx.sock
db_1   | 2021-04-18T13:09:41.038203Z 0 [Warning] [MY-010068] [Server] CA certificate ca.pem is self signed.
db_1   | 2021-04-18T13:09:41.038511Z 0 [System] [MY-013602] [Server] Channel mysql_main configured to support TLS. Encrypted connections are now supported for this channel.
db_1   | 2021-04-18T13:09:41.046768Z 0 [Warning] [MY-011810] [Server] Insecure configuration for --pid-file: Location '/var/run/mysqld' in the path is accessible to all OS users. Consider choosing a different directory.
db_1   | 2021-04-18T13:09:41.156077Z 0 [System] [MY-010931] [Server] /usr/sbin/mysqld: ready for connections. Version: '8.0.23'  socket: '/var/run/mysqld/mysqld.sock'  port: 3306  MySQL Community Server - GPL.
```