### PR TITLE
yarnのタイムアウトの回避

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - ./web:/home/node
     ports:
       - 13000:13000
-    command: /bin/sh -c "yarn install && yarn start"
+    command: /bin/sh -c "yarn install --network-timeout 1000000 && yarn start"
   go:
     build:
       context: .


### PR DESCRIPTION
## Clubhouse Story （対応チケット）
https://app.clubhouse.io/chubachipt21/story/232

## What I did （やったこと）
- yarn installのオプションとして--network-timeout 1000000を設定してdocker-compose up中でのエラーを回避
