### PR TITLE
node_modulesをホストから分離

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     tty: true
     volumes:
       - ./web:/home/node:cached
+      - /home/node/node_modules
     ports:
       - 13000:13000
     command: /bin/sh -c "yarn install --network-timeout 1000000 && yarn start"


### PR DESCRIPTION
## Clubhouse Story （対応チケット）
https://app.clubhouse.io/chubachipt21/story/355

## What I did （やったこと）
- docker-compose.ymlのvolumesに「- /home/node/node_modules」を追加し、node_modulesをホストから分離した

## Notes （備考）
- Mac環境2台で動作することを確認した。docker-compose buildとupで45分→5分に短縮
