### PR TITLE
fixed the fetching image url bug

### DIFF
--- a/internal/infrastructure/repository/feed_repository.go
+++ b/internal/infrastructure/repository/feed_repository.go
@@ -26,13 +26,13 @@ func (repo *feedRepository) All(sourceID int64) (orm.FeedSlice, error) {
 	).All(context.Background(), database.DBCon)
 }
 
-func (repo *feedRepository) Create(sourceID int64, item *gofeed.Item) (*orm.Feed, error) {
+func (repo *feedRepository) Create(sourceID int64, item *gofeed.Item, imageURL string) (*orm.Feed, error) {
 	feed := orm.Feed{
 		SourceID: sourceID,
 		URL:      item.Link,
 		Title:    item.Title,
 		Contents: null.StringFrom(item.Description),
-		ImageURL: null.StringFrom("https://dummyimage.com/600x400/000/fff"), // TODO:
+		ImageURL: null.StringFrom(imageURL),
 	}
 	err := feed.Insert(context.Background(), database.DBCon, boil.Infer())
 

--- a/internal/models/mock_repository_interface.go
+++ b/internal/models/mock_repository_interface.go
@@ -8,9 +8,9 @@ import (
 	reflect "reflect"
 	time "time"
 
+	orm "github.com/ChubachiPT21/paddle/pkg/orm"
 	gomock "github.com/golang/mock/gomock"
 	gofeed "github.com/mmcdole/gofeed"
-	orm "github.com/ChubachiPT21/paddle/pkg/orm"
 )
 
 // MockInterestRepository is a mock of InterestRepository interface.
@@ -89,18 +89,18 @@ func (mr *MockFeedRepositoryMockRecorder) All(sourceID interface{}) *gomock.Call
 }
 
 // Create mocks base method.
-func (m *MockFeedRepository) Create(sourceID int64, item *gofeed.Item) (*orm.Feed, error) {
+func (m *MockFeedRepository) Create(sourceID int64, item *gofeed.Item, imageURL string) (*orm.Feed, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", sourceID, item)
+	ret := m.ctrl.Call(m, "Create", sourceID, item, imageURL)
 	ret0, _ := ret[0].(*orm.Feed)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockFeedRepositoryMockRecorder) Create(sourceID, item interface{}) *gomock.Call {
+func (mr *MockFeedRepositoryMockRecorder) Create(sourceID, item, imageURL interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockFeedRepository)(nil).Create), sourceID, item)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockFeedRepository)(nil).Create), sourceID, item, imageURL)
 }
 
 // MockSourceRepository is a mock of SourceRepository interface.

--- a/internal/models/repository_interface.go
+++ b/internal/models/repository_interface.go
@@ -3,8 +3,8 @@ package models
 import (
 	"time"
 
-	"github.com/mmcdole/gofeed"
 	"github.com/ChubachiPT21/paddle/pkg/orm"
+	"github.com/mmcdole/gofeed"
 )
 
 // InterestRepository is an interface
@@ -15,7 +15,7 @@ type InterestRepository interface {
 // FeedRepository is an interface
 type FeedRepository interface {
 	All(sourceID int64) (orm.FeedSlice, error)
-	Create(sourceID int64, item *gofeed.Item) (*orm.Feed, error)
+	Create(sourceID int64, item *gofeed.Item, imageURL string) (*orm.Feed, error)
 }
 
 // SourceRepository is an interface

--- a/internal/usecase/create_feed.go
+++ b/internal/usecase/create_feed.go
@@ -4,8 +4,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/mmcdole/gofeed"
 	"github.com/ChubachiPT21/paddle/internal/infrastructure/repository"
+	"github.com/mmcdole/gofeed"
+	"github.com/otiai10/opengraph"
 )
 
 // CreateFeed is an usecase to create feeds from the source
@@ -41,10 +42,24 @@ func CreateFeed(sourceID int64) error {
 
 		if latestDateTime.IsZero() || latestDateTime.Before(itemDateTime) {
 			latestDateTime = itemDateTime
-			_, err := feedRepo.Create(sourceID, item)
+			ogp, err := opengraph.Fetch(item.Link)
 			if err != nil {
 				fmt.Println(err)
 				continue
+			}
+
+			if len(ogp.Image) > 0 {
+				_, err = feedRepo.Create(sourceID, item, ogp.Image[0].URL)
+				if err != nil {
+					fmt.Println(err)
+					continue
+				}
+			} else {
+				_, err = feedRepo.Create(sourceID, item, "")
+				if err != nil {
+					fmt.Println(err)
+					continue
+				}
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -42,9 +42,5 @@ func main() {
 		v1,
 		paddle.CreateInterest()...,
 	)
-	routes.AddRoutes(
-		v1,
-		paddle.GetOgpimg()...,
-	)
 	r.Run(":10330") // listen and serve on 0.0.0.0:8080 (for windows "localhost:8080")
 }

--- a/web/.yarnrc
+++ b/web/.yarnrc
@@ -2,4 +2,4 @@
 # yarn lockfile v1
 
 
-lastUpdateCheck 1620575134663
+lastUpdateCheck 1620739047489


### PR DESCRIPTION
## Clubhouse Story （対応チケット）
https://app.clubhouse.io/chubachipt21/story/xxx

## What I did （やったこと）
- previewでimageURLの取得時にバグが起こらないように修正
- usecase内でimageURLの取得を行うように修正

## Notes （備考）
デバッグ方法ですが、loop内でprintすると、いくつかは成功してその後失敗してることがわかります
```
go_1   | [00] http://gifnksm.hatenablog.jp/entry/2021/05/09/155149https://note.com/onecapital/n/n974fecd748dfhttps://ascii.jp/elem/000/004/054/4054418/https://
blog.jxck.io/entries/2021-05-11/end-of-ie.htmlhttps://zenn.dev/ulwlu/articles/cc2443d32e2444https://note.com/fladdict/n/n97d74e754bc4https://zenn.dev/magurotun
a/articles/sponsored-by-denohttps://kray.jp/blog/how-to-docbase-renewal/https://tech.bm-sms.co.jp/entry/2021/05/11/120000https://japanese.engadget.com/windows-
95-icons-024529945.htmlhttps://pc.watch.impress.co.jp/docs/news/1323517.htmlhttps://engineer.fabcross.jp/archeive/210416_valkyrie.htmlhttps://dev.classmethod.j
p/articles/awssummit-2021-training-guide/https://gigazine.net/news/20210511-tor-exit-relay-tracking/https://japan.zdnet.com/article/35170458/https://zenn.dev/a
d5/articles/48671b32c89897https://www.yubico.com/blog/github-now-supports-ssh-security-keys/https://coliss.com/articles/build-websites/operation/design/ui-ux-m
icro-tips-volume-four.htmlhttps://togetter.com/li/1712337https://twitter.com/KeijiKobara/status/13913175998504304672021/05/11 13:42:32 http: panic serving 172.
20.0.1:60742: runtime error: index out of range [0] with length 0
go_1   | [00] goroutine 6 [running]:
```

なので、indexでエラーが起こってるところを `if len(ogp.Image) > 0` みたいな感じでハンドリングしてこの条件に合わない場合をprintすると

```
go_1   | [00] Content type must be text/html
go_1   | [00] []Content type must be text/html
```

みたいなのを返してきてることがわかりました。なのでこの場合はimageURLはnilとする感じにして、そうじゃない場合のみ値を利用するようにするとうまくいく感じですね。
