### PR TITLE
[Ch500] paddle_test.goにテスト追加 for createSourceHandler

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -269,6 +269,7 @@ golang.org/x/net v0.0.0-20190926025831-c00fd9afed17/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a h1:GuSPYbZzB5/dcLNCwLQLsg3obCJtX9IJhpXkvY7kzk0=
 golang.org/x/net v0.0.0-20200301022130-244492dfa37a/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
+golang.org/x/net v0.0.0-20210226172049-e18ecbb05110 h1:qWPm9rbaAMKs8Bq/9LRpbMqxWRVUAQwMI9fVrssnTfw=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -291,6 +292,7 @@ golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9sn
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2 h1:tW2bmiBqwgJj/UpqtC8EpXEZVYOwU0yG4iWbprSVAcs=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
+golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/internal/routes/paddle/paddle.go
+++ b/internal/routes/paddle/paddle.go
@@ -26,6 +26,7 @@ type getSourcesHandler struct {
 }
 
 type createSourceHandler struct {
+	repo models.SourceRepository
 }
 
 type createFeedsHandler struct {
@@ -111,8 +112,7 @@ func (h *createSourceHandler) receive(c *gin.Context) {
 		return
 	}
 
-	sourceRepo := repository.NewSourceRepository()
-	err = sourceRepo.Create(&source)
+	err = h.repo.Create(&source)
 	if err != nil {
 		fmt.Println(err)
 		c.JSON(http.StatusInternalServerError, nil)
@@ -196,8 +196,8 @@ func GetSources(repo models.SourceRepository) routes.Routes {
 }
 
 // CreateSource creates a new source
-func CreateSource() routes.Routes {
-	handler := new(createSourceHandler)
+func CreateSource(repo models.SourceRepository) routes.Routes {
+	handler := createSourceHandler{repo}
 
 	return routes.Routes{
 		{

--- a/internal/routes/paddle/paddle_test.go
+++ b/internal/routes/paddle/paddle_test.go
@@ -3,6 +3,7 @@ package paddle_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/ChubachiPT21/paddle/internal/models"
@@ -48,6 +49,30 @@ func TestGetSourcesHandler_handle(t *testing.T) {
 
 		w := httptest.NewRecorder()
 		c, _ := gin.CreateTestContext(w)
+
+		routeStruct.Handler(c)
+		assert.Equal(t, http.StatusOK, w.Result().StatusCode)
+	})
+}
+
+func TestCreateSourceHandler_receive(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mock := models.NewMockSourceRepository(ctrl)
+	mock.EXPECT().Create(gomock.Any()).DoAndReturn(func(_ *orm.Source) error {
+		return nil
+	})
+
+	t.Run("return 200", func(t *testing.T) {
+		routeStruct := paddle.CreateSource(mock)[0]
+
+		w := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(w)
+
+		body := strings.NewReader("") // 空でもbodyがないとtestを通らない
+		c.Request, _ = http.NewRequest("POST", "vi/sources", body)
+		c.Request.Header.Set("Content-Type", "application/x-www-form-urlencoded") // typeは適当です
 
 		routeStruct.Handler(c)
 		assert.Equal(t, http.StatusOK, w.Result().StatusCode)

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 	)
 	routes.AddRoutes(
 		v1,
-		paddle.CreateSource()...,
+		paddle.CreateSource(repository.NewSourceRepository())...,
 	)
 	routes.AddRoutes(
 		v1,


### PR DESCRIPTION
## Clubhouse Story （対応チケット）
https://app.clubhouse.io/chubachipt21/story/500

## What I did （やったこと）
- main.goのCreateSource呼び出しに引数を追加
- paddle.goのcreateSourceHandler定義にSourceRepository型の変数を追加
- paddle.goのCreateSourceで受け取ったSourceRepositoryを使用する用に修正
- createSourceHandlerのreceive内のNewSourceRepository呼び出しを削除
- paddle_test.goにTestCreateSourceHandler_receiveを追加
