### PR TITLE
check authentication status before rendering pages

### DIFF
--- a/internal/routes/paddle/paddle_test.go
+++ b/internal/routes/paddle/paddle_test.go
@@ -94,9 +94,9 @@ func TestCreateInterestHandler_receive(t *testing.T) {
 		c, _ := gin.CreateTestContext(w)
 		c.Params = gin.Params{gin.Param{Key: "feed_id", Value: "1"}}
 
-		body := strings.NewReader("") 
+		body := strings.NewReader("")
 		c.Request, _ = http.NewRequest("POST", "/sources/:id/feeds/:feed_id/interest", body)
-		c.Request.Header.Set("Content-Type", "application/x-www-form-urlencoded") 
+		c.Request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 		routeStruct.Handler(c)
 		assert.Equal(t, http.StatusOK, w.Result().StatusCode)
 	})

--- a/main.go
+++ b/main.go
@@ -53,6 +53,10 @@ func main() {
 		v1,
 		paddle.Signup(repository.NewUserRepository())...,
 	)
+	routes.AddRoutes(
+		v1,
+		paddle.GetAuthentication(repository.NewUserRepository())...,
+	)
 	r.Run(":10330") // listen and serve on 0.0.0.0:8080 (for windows "localhost:8080")
 }
 

--- a/web/src/actions/authenticationActions.ts
+++ b/web/src/actions/authenticationActions.ts
@@ -66,6 +66,24 @@ export const signIn = (authenticationInput: IAuthentication) => {
   }
 }
 
+export const getAuthentication = () => {
+  return (dispatch: Dispatch) => {
+    dispatch(authenticationStart())
+    return authenticationRequest
+      .getAuthentication()
+      .then((res) => {
+        if (res.data) {
+          dispatch(authenticationSuccess(res.data))
+        } else {
+          dispatch(authenticationError(new Error()))
+        }
+      })
+      .catch((error) => {
+        dispatch(authenticationError(error))
+      })
+  }
+}
+
 export type AuthenticationAction =
   | IAuthenticationAction
   | IAuthenticationSuccess

--- a/web/src/api/authenticationRequest.ts
+++ b/web/src/api/authenticationRequest.ts
@@ -1,4 +1,4 @@
-import { IAuthentication } from '../type'
+import { IAuthentication, IUser } from '../type'
 import axios from '../http/axios'
 
 const authenticationRequest = {
@@ -13,6 +13,9 @@ const authenticationRequest = {
       email: user.email,
       password: user.password,
     })
+  },
+  getAuthentication: () => {
+    return axios.get<IUser>(`/v1/authentication`)
   },
 }
 

--- a/web/src/containers/pages/AuthenticationPage.tsx
+++ b/web/src/containers/pages/AuthenticationPage.tsx
@@ -1,10 +1,11 @@
-import React, { FC } from 'react'
+import React, { FC, useEffect } from 'react'
 import { HeaderNavigation } from 'src/components/molecules/Header'
 import AuthenticationForm from 'src/containers/organisms/AuthenticationForm'
 import DefaultTemplate from 'src/containers/templates/DefaultTemplate'
-import { useSelector } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 import { IUser } from 'src/type'
 import { useHistory } from 'react-router'
+import { getAuthentication } from 'src/actions/authenticationActions'
 
 export enum AuthType {
   SIGNUP = 'SIGNUP',
@@ -16,15 +17,22 @@ type Props = {
 }
 
 const AuthenticationPage: FC<Props> = ({ authType }) => {
+  const dispatch = useDispatch()
   const history = useHistory()
   const user = useSelector(
     (state: { user: { user: IUser } }) => state.user.user
   )
 
-  if (user.token) {
-    // TODO:
-    history.replace('/')
-  }
+  useEffect(() => {
+    if (!user.token) {
+      const asyncFunc = () => {
+        dispatch(getAuthentication())
+      }
+      asyncFunc()
+    }
+  }, [])
+
+  if (user.token) history.replace('/')
 
   return (
     <DefaultTemplate defaultNavigation={HeaderNavigation.headerRightMenu}>

--- a/web/src/containers/pages/FeedsPage.tsx
+++ b/web/src/containers/pages/FeedsPage.tsx
@@ -1,28 +1,45 @@
 import React, { FC, useEffect } from 'react'
-import { useDispatch } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 import FeedList from 'src/containers/organisms/FeedList'
 import { HeaderNavigation } from 'src/components/molecules/Header'
 import { fetchSources } from 'src/actions/sourceActions'
 import DefaultTemplate from 'src/containers/templates/DefaultTemplate'
 import FeedTemplate from 'src/containers/templates/FeedTemplate'
+import { IUser } from 'src/type'
+import { getAuthentication } from 'src/actions/authenticationActions'
+import { useHistory } from 'react-router'
 
 const FeedsPage: FC = () => {
   const dispatch = useDispatch()
+  const history = useHistory()
+  const user = useSelector(
+    (state: { user: { user: IUser } }) => state.user.user
+  )
+  const authenticationError = useSelector(
+    (state: { user: { error: boolean } }) => state.user.error
+  )
 
   useEffect(() => {
     const asyncFunc = () => {
       dispatch(fetchSources())
+      if (!user.token) dispatch(getAuthentication())
     }
     asyncFunc()
   }, [])
 
-  return (
-    <DefaultTemplate defaultNavigation={HeaderNavigation.home}>
-      <FeedTemplate>
-        <FeedList />
-      </FeedTemplate>
-    </DefaultTemplate>
-  )
+  if (authenticationError) history.push('/signin')
+
+  if (user.token) {
+    return (
+      <DefaultTemplate defaultNavigation={HeaderNavigation.home}>
+        <FeedTemplate>
+          <FeedList />
+        </FeedTemplate>
+      </DefaultTemplate>
+    )
+  }
+
+  return <div />
 }
 
 export default FeedsPage

--- a/web/src/reducers/userReducers.ts
+++ b/web/src/reducers/userReducers.ts
@@ -27,6 +27,7 @@ const reducer = (
       return {
         ...state,
         user: action.payload.user,
+        error: false,
       }
     case AuthenticationActionTypes.AUTHENTICATION_ERROR:
       return {


### PR DESCRIPTION
## Clubhouse Story （対応チケット）
https://app.clubhouse.io/chubachipt21/story/615

## What I did （やったこと）
- 認証状況を確認するendpointを用意
- 認証済みだった場合
  - signup or signinページにlandingすると `/` にredirectされる
- 未認証だった場合
  - `/` にlandingすると、 `/signin` にredirectされる

## Notes （備考）
state更新中にrenderingするなというwarningがでるが、dispatchしてstate確認してるやり方での回避がよくわからない..
一旦warningなので放置しています。

```
Warning: Cannot update during an existing state transition (such as within `render`). Render methods should be a pure function of props and state.
```