### PR TITLE
SessionCookie設定をクロスドメイン許可にしAPIドメインをhttpsに変更

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"os"
-
+	"net/http"
 	"github.com/gin-contrib/sessions"
 	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
@@ -22,6 +22,7 @@ func main() {
 	r.Use(CORS())
 
 	store := cookie.NewStore([]byte("secret"))
+	store.Options(sessions.Options{SameSite: http.SameSiteNoneMode, Secure: true})
 	r.Use(sessions.Sessions("paddleSession", store))
 
 	v1 := r.Group("/v1")

--- a/web/.env.production
+++ b/web/.env.production
@@ -1,1 +1,1 @@
-REACT_APP_API_URL=http://54.248.63.70:10330
+REACT_APP_API_URL=https://cdp-aiit-20745140.work


### PR DESCRIPTION
## Clubhouse Story （対応チケット）
https://app.clubhouse.io/chubachipt21/story/713/cookie

## What I did （やったこと）
1. Go APIが起動しているEC2上にNginxをインストール
2. EC2上に無料オレオレ証明書を生成しnginx.confで読み込ませる
3. NginxをAPIのリバースプロキシとして起動
4. 証明書に設定したドメインのDNSサーバーに同ドメインのAレコード＝EC2 IPアドレスとして追加
5. フロントエンドからのリクエスト向き先を同ドメインhttpsに向ける

ドメインは応急処置として https://cdp-aiit-20745140.work になりました。APIだから表に見えないから何でもよいと思う

## Notes （備考）
Google Chrome 80 Updateによって次の変更が加わった（他のブラウザも3rd Party Cookieの対応で同じ方向に移行）
- CookiesのデフォルトSameSite設定 = Lax
- SameSite = Noneの安全でないCookieはリジェクトされる
  - クロスオリジンでhttps通信を使用していない場合はCookieが弾かれる
  - ただし、localhostは開発者用として無視される

https://www.docusign.jp/blog/google-chrome-80-samesite-cookie

SameSiteの挙動詳細
https://developer.mozilla.org/ja/docs/Web/HTTP/Headers/Set-Cookie/SameSite