### PR TITLE
atomsのテストを追加する

### DIFF
--- a/web/src/test/components/atoms/AddSource.test.tsx
+++ b/web/src/test/components/atoms/AddSource.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import AddSource from 'src/components/atoms/AddSource'
+
+describe('atoms/AddSource', () => {
+  test('should render the component', () => {
+    render(<AddSource onClick={jest.fn()} />)
+    expect(screen.getByAltText('icon-add-source')).toBeInTheDocument()
+  })
+})

--- a/web/src/test/components/atoms/FollowButton.test.tsx
+++ b/web/src/test/components/atoms/FollowButton.test.tsx
@@ -1,0 +1,19 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import FollowButton from 'src/components/atoms/FollowButton'
+
+describe('atoms/FollowButton', () => {
+  test('should have following button', () => {
+    render(<FollowButton isFollowing onClick={jest.fn()} />)
+    expect(screen.getByRole('button')).toHaveClass('search__btnFollowing')
+    expect(screen.getByRole('button')).not.toHaveClass('search__btnFollow')
+    expect(screen.getByRole('button').textContent).toEqual('FOLLOWING')
+  })
+
+  test('should have follow button', () => {
+    render(<FollowButton isFollowing={false} onClick={jest.fn()} />)
+    expect(screen.getByRole('button')).toHaveClass('search__btnFollow')
+    expect(screen.getByRole('button')).not.toHaveClass('search__btnFollowing')
+    expect(screen.getByRole('button').textContent).toEqual('FOLLOW')
+  })
+})

--- a/web/src/test/components/atoms/Input.test.tsx
+++ b/web/src/test/components/atoms/Input.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Input from 'src/components/atoms/Input'
+
+const props = {
+  className: 'testClassName',
+  type: 'text',
+  placeholder: 'testPlaceholder',
+  onChange: jest.fn(),
+  onKeyDown: jest.fn(),
+  title: 'testTitle',
+}
+describe('atoms/Input', () => {
+  test('should render the component and only have input element', () => {
+    render(
+      <Input
+        className={props.className}
+        type={props.type}
+        placeholder={props.placeholder}
+        onChange={jest.fn()}
+      />
+    )
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+    expect(screen.queryByText(`${props.title}`)).toBeNull()
+  })
+
+  test('should render the component and have input,span element', () => {
+    render(
+      <Input
+        className={props.className}
+        type={props.type}
+        placeholder={props.placeholder}
+        onChange={jest.fn()}
+        onKeyDown={jest.fn()}
+        title={props.title}
+      />
+    )
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+    expect(screen.getByText(`${props.title}`)).toBeInTheDocument()
+  })
+})

--- a/web/src/test/components/atoms/PrimaryButton.test.tsx
+++ b/web/src/test/components/atoms/PrimaryButton.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import PrimaryButton from 'src/components/atoms/PrimaryButton'
+
+describe('atoms/PrimartButton', () => {
+  test('should render the component and show button name', () => {
+    render(<PrimaryButton buttonName="testButtonName" onClick={jest.fn()} />)
+    expect(screen.getByRole('button')).toHaveTextContent('testButtonName')
+  })
+})

--- a/web/src/test/components/atoms/Search.test.tsx
+++ b/web/src/test/components/atoms/Search.test.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import Search from 'src/components/atoms/Search'
+
+describe('atoms/Search', () => {
+  test('should render the component', () => {
+    render(<Search onClick={jest.fn()} />)
+    expect(screen.getByAltText('icon-search')).toBeInTheDocument()
+  })
+})

--- a/web/src/test/components/atoms/SourceHeading.test.tsx
+++ b/web/src/test/components/atoms/SourceHeading.test.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import SourceHeading from 'src/components/atoms/SourceHeading'
+import { ISource } from 'src/type'
+
+const source: ISource = {
+  id: 1,
+  title: 'test title',
+  count: 1,
+}
+describe('atoms/SourceHeading', () => {
+  test('should render the component', () => {
+    render(<SourceHeading source={source} />)
+    expect(screen.getByText(`${source.title}`)).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Clubhouse Story （対応チケット）
https://app.clubhouse.io/chubachipt21/story/ch720

## What I did （やったこと）
- atomsのテストケースを追加しました

## Notes （備考）
yan:paddle yan$ docker-compose exec web yarn test  
yarn run v1.22.5
$ react-scripts test --watchAll=false
 PASS  src/test/components/atoms/SourceHeading.test.tsx
 PASS  src/test/components/atoms/Input.test.tsx
 PASS  src/test/components/atoms/FollowButton.test.tsx
 PASS  src/test/components/atoms/Home.test.tsx
 PASS  src/test/components/atoms/AddSource.test.tsx
 PASS  src/test/components/atoms/Explore.test.tsx
 PASS  src/test/components/atoms/Search.test.tsx
 PASS  src/test/components/atoms/PrimaryButton.test.tsx

Test Suites: 8 passed, 8 total
Tests:       10 passed, 10 total
Snapshots:   0 total
