### PR TITLE
Ch739

### DIFF
--- a/internal/routes/paddle/paddle.go
+++ b/internal/routes/paddle/paddle.go
@@ -106,18 +106,26 @@ func hasToken(c *gin.Context, repo models.UserRepository) bool {
 	return true
 }
 
+func validateEmailPassword(c *gin.Context) (authenticationRequest authenticationRequest, valid bool) {
+	valid = true
+	c.BindJSON(&authenticationRequest)
+
+	emailError := validation.Validate(authenticationRequest.Email, is.Email)
+	passwordError := validation.Validate(authenticationRequest.Password, validation.Required)
+	if emailError != nil || passwordError != nil {
+		c.JSON(http.StatusUnauthorized, nil)
+		valid = false
+	}
+	return
+}
+
 func (h *signupHandler) receive(c *gin.Context) {
 	if hasToken(c, h.repo) {
 		return
 	}
 
-	var authenticationRequest authenticationRequest
-	c.BindJSON(&authenticationRequest)
-
-	emailErr := validation.Validate(authenticationRequest.Email, is.Email)
-	passwordErr := validation.Validate(authenticationRequest.Password, validation.Required)
-	if emailErr != nil || passwordErr != nil {
-		c.JSON(http.StatusUnauthorized, nil)
+	authenticationRequest, valid := validateEmailPassword(c)
+	if !valid {
 		return
 	}
 
@@ -148,13 +156,8 @@ func (h *signinHandler) receive(c *gin.Context) {
 		return
 	}
 
-	var authenticationRequest authenticationRequest
-	c.BindJSON(&authenticationRequest)
-
-	emailErr := validation.Validate(authenticationRequest.Email, is.Email)
-	passwordErr := validation.Validate(authenticationRequest.Password, validation.Required)
-	if emailErr != nil || passwordErr != nil {
-		c.JSON(http.StatusUnauthorized, nil)
+	authenticationRequest, valid := validateEmailPassword(c)
+	if !valid {
 		return
 	}
 

--- a/internal/routes/paddle/paddle.go
+++ b/internal/routes/paddle/paddle.go
@@ -151,6 +151,13 @@ func (h *signinHandler) receive(c *gin.Context) {
 	var authenticationRequest authenticationRequest
 	c.BindJSON(&authenticationRequest)
 
+	emailErr := validation.Validate(authenticationRequest.Email, is.Email)
+	passwordErr := validation.Validate(authenticationRequest.Password, validation.Required)
+	if emailErr != nil || passwordErr != nil {
+		c.JSON(http.StatusUnauthorized, nil)
+		return
+	}
+
 	user, err := h.repo.FindByEmail(authenticationRequest.Email)
 	if err != nil || user == nil || bcrypt.CompareHashAndPassword([]byte(user.EncryptedPassword.String), []byte(authenticationRequest.Password)) != nil {
 		c.JSON(http.StatusUnauthorized, nil)


### PR DESCRIPTION
## Clubhouse Story （対応チケット）
https://app.clubhouse.io/chubachipt21/story/739

## What I did （やったこと）
- サインインのハンドラにemailとpasswordのバリデーションを追加
- サインアップとサインインでまったく同じ行が21行あったのでリファクタリング
- 　トークンの存在確認をメソッド化してサインアップとサインインで共用
- 　emailとpasswordのバリデーションをメソッド化してサインアップとサインインで共用

gitのdiffは見づらいですが、signupHandlerとsigninHandlerの先頭から21行ほどを2つのメソッドに切り出してメソッド呼び出しに変えているだけです。